### PR TITLE
Since PHP 7.3.0 able to set sameSite cookie value

### DIFF
--- a/include/cookieconsent.api.php
+++ b/include/cookieconsent.api.php
@@ -16,7 +16,12 @@ if($array['consent']==true){
 		#pwg_set_cookie_var("cc_persistent_cookie", true, $expire=(time() + (86400 * 365))); #cookie is set for wrong path
 		$fpath = $_SERVER['REQUEST_URI']; #"/piwigo/plugins/cookieconsent/include/cookieconsent.api.php";
 		$cpath = substr($fpath,0,strpos($fpath,"plugins/cookieconsent/include/cookieconsent.api.php")); #returns part before 'plugins', here /piwigo/
-		setcookie('pwg_cc_persistent_cookie', true, (time() + (86400 * 365)), $cpath);
+		setcookie('pwg_cc_persistent_cookie', true, array ( # since PHP 7.3.0
+				'expires' => time() + (86400 * 365),
+				'path' => $cpath,
+				'samesite' => 'Strict', # None || Lax  || Strict
+			)
+	        );
 	}
 print_r($conf);
 }


### PR DESCRIPTION
Before PHP 7.3.0, a sameSite cookie default value is used by the browser. Will browsers behave as expected ?